### PR TITLE
update vue to 2.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@
     (factory((global.VueTyped = global.VueTyped || {}),global.Vue));
 }(this, (function (exports,Vue) { 'use strict';
 
+Vue = 'default' in Vue ? Vue['default'] : Vue;
+
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var vueInternalPropNames = Object.getOwnPropertyNames(new Vue());

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "ts-loader": "^0.8.2",
     "ts-node": "^1.6.1",
     "typescript": "^2.0.3",
-    "vue": "^2.1.8",
+    "vue": "^2.2.6",
     "webpack": "^1.13.1",
     "webpack-merge": "^0.13.0"
   },

--- a/src/component.ts
+++ b/src/component.ts
@@ -3,7 +3,7 @@
  */
 
 
-import * as Vue from 'vue'
+import Vue from 'vue'
 import { ComponentOptions } from 'vue/types/options';
 import { BuildOptions } from './utils';
 

--- a/src/mixins-global.ts
+++ b/src/mixins-global.ts
@@ -2,7 +2,7 @@
  * Vue Global Mixins
  */
 
-import * as Vue from 'vue'
+import Vue from 'vue'
 import { ComponentOptions } from 'vue/types/options';
 import { BuildOptions } from './utils';
 

--- a/src/mixins.ts
+++ b/src/mixins.ts
@@ -2,7 +2,7 @@
  * Vue Mixins
  */
 
-import * as Vue from 'vue'
+import Vue from 'vue'
 import { VirtualClass } from '../'
 
 export function Mixin<T>(component: { new () : T; }): VirtualClass<T> {

--- a/src/options.ts
+++ b/src/options.ts
@@ -2,7 +2,7 @@
  * Vue Options
  */
 
-import * as Vue from 'vue'
+import Vue from 'vue'
 import { ComponentOptions } from 'vue/types/options';
 import { BuildOptions } from './utils';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { VirtualClass } from '../'
-import * as Vue from 'vue'
+import Vue from 'vue'
 
 var vueInternalPropNames = Object.getOwnPropertyNames(new Vue());
 var vueInternalHooks = [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "isolatedModules": false,
     "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
     "declaration": false,
     "noImplicitAny": false,
     "removeComments": true,


### PR DESCRIPTION
> In Vue 2.2 we introduced dist files exposed as ES modules, which will be used by default by webpack 2. Unfortunately, this introduced an unintentional breaking change because with TypeScript + webpack 2, import Vue = require('vue') will now return a synthetic ES module object instead of Vue itself.

[TypeScript Support](https://vuejs.org/v2/guide/typescript.html)